### PR TITLE
Replace 'Reading Group' homepage card with slack invite

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -16,6 +16,8 @@ theme = 'eadk'
   youtube = "https://www.youtube.com/channel/UCGmtXxP3dHWz9Tte_k9spzQ/featured"
   donateURL = "https://giveffektivt.dk"
   bookChatURL = "/guidance/"
+  # TODO: replace with a never-expiring Slack invite link before merging (workspace owner/admin can generate one).
+  slackInviteURL = "https://join.slack.com/t/REPLACE-ME/shared_invite/REPLACE-ME"
 
 [menu]
   [[menu.main]]

--- a/hugo.toml
+++ b/hugo.toml
@@ -16,8 +16,7 @@ theme = 'eadk'
   youtube = "https://www.youtube.com/channel/UCGmtXxP3dHWz9Tte_k9spzQ/featured"
   donateURL = "https://giveffektivt.dk"
   bookChatURL = "/guidance/"
-  # TODO: replace with a never-expiring Slack invite link before merging (workspace owner/admin can generate one).
-  slackInviteURL = "https://join.slack.com/t/REPLACE-ME/shared_invite/REPLACE-ME"
+  slackInviteURL = "https://join.slack.com/t/eadenmark/shared_invite/zt-34qnyn9ma-gM2gCSp2I~xQN96kp~FZlA"
 
 [menu]
   [[menu.main]]

--- a/themes/eadk/layouts/index.html
+++ b/themes/eadk/layouts/index.html
@@ -34,15 +34,16 @@
         <p>Meet like-minded people at socials, talks, and workshops across Denmark.</p>
       </a>
 
-      <a href="/community/" class="pathway-card">
+      <a href="{{ .Site.Params.slackInviteURL }}" class="pathway-card">
         <div class="pathway-icon">
-          <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" width="48" height="48">
-            <path d="M6 8c6-2 12 0 18 3c6-3 12-5 18-3v30c-6-2-12 0-18 3c-6-3-12-5-18-3V8z"/>
-            <path d="M24 11v30"/>
+          <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="48" height="48">
+            <path d="M8 10h32a2 2 0 0 1 2 2v20a2 2 0 0 1-2 2H20l-8 8v-8H8a2 2 0 0 1-2-2V12a2 2 0 0 1 2-2z"/>
+            <path d="M16 20h16"/>
+            <path d="M16 26h10"/>
           </svg>
         </div>
-        <h3>Join a Reading Group</h3>
-        <p>Explore key ideas in EA through structured discussions with a small group.</p>
+        <h3>Join the Slack</h3>
+        <p>Chat with the Danish EA community, ask questions, and stay in the loop.</p>
       </a>
 
       <a href="{{ .Site.Params.bookChatURL }}" class="pathway-card">


### PR DESCRIPTION
Closes #25, closes #18. Replaces the broken link reading group card with an invite to the Slack group. A Slack admin is needed to generate a non expiring invite link, which needs to be put in hugo.toml as the 'slackInviteURL'.