### PR TITLE
:sparkles: Change donor box embed to membership instead of donation

### DIFF
--- a/content/become-a-member.md
+++ b/content/become-a-member.md
@@ -21,4 +21,4 @@ reach out to us._
 
 ## Ready to Join?
 
-<script type="module" src="https://donorbox.org/widgets.js" async></script><dbox-widget campaign="become-a-member-of-effective-altruism-denmark" type="donation_form" enable-auto-scroll="true"></dbox-widget>
+<script type="module" src="https://donorbox.org/widgets.js" async></script><dbox-widget campaign="ea-denmark-membership" type="donation_form" enable-auto-scroll="true"></dbox-widget>


### PR DESCRIPTION
Change the donor box embed to target the membership campaign instead of the donation campaign. This makes it much easier to keep track of who is actually a member.