### PR TITLE
Fix Slack links on contact page rendering as literal text

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -3,11 +3,11 @@ title: "Contact Us"
 subtitle: "We'd love to hear from you"
 ---
 
-**Slack** Our <a href="{{ .Site.Params.slackInviteURL }}">Slack</a> is the best way to get in touch with us and keep an eye on what's happening.
+**Slack** Our [Slack]({{< param slackInviteURL >}}) is the best way to get in touch with us and keep an eye on what's happening.
 
 **Copenhagen office**
 Vesterbrogade 149, Bygning 5 1620 København \
-Ask in our <a href="{{ .Site.Params.slackOfficeChannelURL }}">office channel</a> when people are around.
+Ask in our [office channel]({{< param slackOfficeChannelURL >}}) when people are around.
 
 **Email:** [contact@effectivealtruism.dk](mailto:contact@effectivealtruism.dk)
 


### PR DESCRIPTION
The two Slack links on the contact page use `{{ .Site.Params.slackInviteURL }}` template syntax. Hugo does not evaluate Go templates inside `content/` files, so both links publish with the literal string as their `href` and are dead on the live site.